### PR TITLE
Modify parse function to return list of matches

### DIFF
--- a/src/main/kotlin/org/sandoval/kotlintsparser/ParserDisplay.kt
+++ b/src/main/kotlin/org/sandoval/kotlintsparser/ParserDisplay.kt
@@ -8,7 +8,7 @@ import java.io.File
 @Component
 class ParserDisplay {
 
-    fun parse(code: String): String {
+    fun parse(code: String): List<String> {
 
         val classloader = Thread.currentThread().contextClassLoader
         val f = classloader.getResource("test-files/main.js")
@@ -34,11 +34,13 @@ class ParserDisplay {
         val cursor = TSQueryCursor()
         cursor.exec(query, rootNode)
         val match = TSQueryMatch()
+        val matches = mutableListOf<String>()
         while (cursor.nextMatch(match)) {
             match.captures.forEach {
                 val node = it.node
 
                 val text = source.substring(node.startByte, node.endByte)
+                matches.add(text)
                 println("---")
                 println(text)
 
@@ -46,7 +48,7 @@ class ParserDisplay {
         }
 
 
-        return "fff"
+        return matches
     }
 
 }

--- a/src/main/kotlin/org/sandoval/kotlintsparser/RestController.kt
+++ b/src/main/kotlin/org/sandoval/kotlintsparser/RestController.kt
@@ -1,11 +1,13 @@
 package org.sandoval.kotlintsparser
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
 
 @RestController
 class HelloWorldController(val parser: ParserDisplay) {
     @GetMapping("/")
-    fun hello(): String {
-        return parser.parse("gff")
+    fun hello(): ResponseEntity<List<String>> {
+        val matches = parser.parse("gff")
+        return ResponseEntity.ok(matches)
     }
 }


### PR DESCRIPTION
Modify the `parse` function in `ParserDisplay` class to return a list of strings containing the text of all matches.

* Initialize an empty list of strings to store the matches.
* Collect the text of each match into the list.
* Return the list of strings at the end of the function.

Modify the `hello` function in `RestController` class to return the list of strings as a JSON response.

* Use `ResponseEntity` to wrap the list of strings.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Yote-Coder-Glenn/kotlin-treesitter-experiment/pull/1?shareId=35387413-8f89-40e2-8378-68648ec9b541).